### PR TITLE
Add curl flag to follow redirects

### DIFF
--- a/Steamy_Cats
+++ b/Steamy_Cats
@@ -29,7 +29,7 @@ function parse_config()
 
 	# Download the Community Profile
 	echo "Downloading your community profile, if public, and then getting full list of games you own"
-	curl -s -o /var/tmp/Steamy_Cats/Community_Profile https://steamcommunity.com/profiles/"$WEBACCNUM"/games/?tab=all || \
+	curl -s -L -o /var/tmp/Steamy_Cats/Community_Profile "https://steamcommunity.com/profiles/$WEBACCNUM/games/?tab=all" || \
 		echo "Failed to download community profile"
 
 	# Find the JSON containing our games, then extract the APP ID with JQ


### PR DESCRIPTION
Fixes a big issue where if a Steam Profile redirects to an /id/\<username\> url the script will think your profile is set to private. Closes #11 